### PR TITLE
Log the papis library directory after init is done

### DIFF
--- a/lua/papis/init.lua
+++ b/lua/papis/init.lua
@@ -108,6 +108,7 @@ function M.start()
 		end
 	end
 
+	log.debug("Library Directory: " .. config["papis_python"]["dir"])
 	log.debug("Papis.nvim up and running")
 end
 


### PR DESCRIPTION
I'm starting with a small one: I had an issue setting up papis.nvim on different machines, the sqlite database was constantly empty. I finally figured it out (next PR) and logging the debug directory was a crucial step for this.