### PR TITLE
Expand library directory specified by user

### DIFF
--- a/lua/papis/fs-watcher.lua
+++ b/lua/papis/fs-watcher.lua
@@ -17,7 +17,7 @@ local api = vim.api
 
 local log = require("papis.logger")
 local config = require("papis.config")
-local library_dir = Path:new(config["papis_python"]["dir"]):absolute()
+local library_dir = Path:new(config["papis_python"]["dir"]):expand()
 local info_name = config["papis_python"]["info_name"]
 local does_pid_exist = require("papis.utils").does_pid_exist
 local db = require("papis.sqlite-wrapper")

--- a/lua/papis/init.lua
+++ b/lua/papis/init.lua
@@ -108,7 +108,6 @@ function M.start()
 		end
 	end
 
-	log.debug("Library Directory: " .. config["papis_python"]["dir"])
 	log.debug("Papis.nvim up and running")
 end
 

--- a/lua/papis/init.lua
+++ b/lua/papis/init.lua
@@ -108,6 +108,7 @@ function M.start()
 		end
 	end
 
+	log.debug("Library Directory: " .. config["papis_python"]["dir"])
 	log.debug("Papis.nvim up and running")
 end
 

--- a/lua/papis/papis-storage.lua
+++ b/lua/papis/papis-storage.lua
@@ -108,7 +108,7 @@ local function make_full_paths(filenames, path)
 
 	local full_paths = {}
 	for _, filename in ipairs(filenames) do
-		local full_path = Path:new(path, filename):absolute()
+		local full_path = Path:new(path, filename):expand()
 		table.insert(full_paths, full_path)
 	end
 	return full_paths
@@ -126,7 +126,7 @@ end
 ---@param paths? table #A list with paths of papis entries
 ---@return table #A list of { path = path, mtime = mtime } values
 function M.get_metadata(paths)
-	paths = paths or Scan.scan_dir(library_dir:absolute(), { depth = 2, search_pattern = info_name })
+	paths = paths or Scan.scan_dir(library_dir:expand(), { depth = 2, search_pattern = info_name })
 	local metadata = {}
 	for _, path in ipairs(paths) do
 		local mtime = fs_stat(path).mtime.sec


### PR DESCRIPTION
I use `papis.nvim` on two machines which have different hostnames. My nvim
config and my papis directory are version controlled and under the same paths
starting from the home directory. I therefore specified the following library
directory in my config:

```
papis_python = {
          dir = "~/astro/papers",
},
```

This did not work, though it should in my opinion.

To make it work, the local library directory should be resolved using the `expand` rather than the `absolute` method,
see the implementations from [plenary](https://github.com/nvim-lua/plenary.nvim/blob/4b7e52044bbb84242158d977a50c4cbcd85070c7/lua/plenary/path.lua#L302). `absolute` does not resolve `~` while `expand` does.