### PR TITLE
Add option to always insert plain reference

### DIFF
--- a/doc/papis.txt
+++ b/doc/papis.txt
@@ -232,6 +232,8 @@ Full list of configuration options (with defaults):
     
     -- What citation format to use when none is defined for the current filetype.
     cite_formats_fallback = "plain",
+    -- Always insert the plain citation format
+    always_use_plain = false,
     
     -- Enable default keymaps.
     enable_keymaps = false,

--- a/lua/papis/config.lua
+++ b/lua/papis/config.lua
@@ -49,6 +49,7 @@ local default_config = {
 		org = "[cite:@%s]",
 	},
 	cite_formats_fallback = "plain",
+	always_use_plain = false,
 	enable_keymaps = false,
 	enable_commands = true,
 	enable_fs_watcher = true,

--- a/lua/papis/utils.lua
+++ b/lua/papis/utils.lua
@@ -29,9 +29,14 @@ function M.get_cite_format(filetype)
 	local config = require("papis.config")
 	local cite_formats = config["cite_formats"]
 	local cite_formats_fallback = config["cite_formats_fallback"]
-	local cite_format = cite_formats[filetype] or cite_formats_fallback
 
-	return cite_format
+	if config["always_use_plain"] then
+		local cite_format = cite_formats["plain"] or "%s"
+		return cite_format
+	else
+		local cite_format = cite_formats[filetype] or cite_formats[cite_formats_fallback]
+		return cite_format
+	end
 end
 
 ---Checks if a given executable exists


### PR DESCRIPTION
The `alwayse_use_plain` option overrides the defined cite-formats for all filetypes. Default is `false`.