### PR TITLE
Remove dependency on lyaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,16 +77,6 @@ use({
     "MunifTanjim/nui.nvim",
     "nvim-treesitter/nvim-treesitter",
   },
-  rocks = {
-    {
-      "lyaml" 
-      -- If using macOS or Linux, you may need to install the `libyaml` (and
-      -- possibly the `libyaml-devel`) package.
-      -- If you install libyaml with homebrew you will need to set the YAML_DIR
-      -- to the location of the homebrew installation of libyaml e.g.
-      -- env = { YAML_DIR = '/opt/homebrew/Cellar/libyaml/0.2.5/' },
-    }
-  },
   config = function()
     require("papis").setup(
     -- Your configuration goes here
@@ -95,9 +85,31 @@ use({
 })
 ```
 
+With lazy.nvim:
+
+```lua
+{
+  "jghauser/papis.nvim",
+  dependencies = {
+    "kkharji/sqlite.lua",
+    "nvim-lua/plenary.nvim",
+    "MunifTanjim/nui.nvim",
+    "nvim-treesitter/nvim-treesitter",
+  },
+  config = function()
+    require("papis").setup({
+    -- Your configuration goes here
+    })
+  end,
+}
+```
+
 With lazy.nvim: because lua rocks are currently unsupported, installation is a bit more fiddly. See [this issue](https://github.com/jghauser/papis.nvim/issues/18) for some hints.
 
-*Papis version*: papis.nvim is meant to be used in conjunction with papis and won't run if it doesn't find the `papis` executable. Note that for the note creation feature to work, it is currently required to use the git version (with commit `d11ff99`).
+Additional dependencies:
+
+- *papis*: papis.nvim is meant to be used in conjunction with papis and won't run if it doesn't find the `papis` executable. Note that for the note creation feature to work, it is currently required to use the git version (with commit `d11ff99`).
+- *yq*: papis.nvim requires the [yq](https://github.com/mikefarah/yq) utility to convert `.yaml` files to `.json` (which can then be read by neovim). Note that papis.nvim doesn't (currently) support the [python yq](https://github.com/kislyuk/yq).
 
 *Neovim version*: papis.nvim is being tested on the latest stable version.
 
@@ -193,6 +205,9 @@ data_tbl_schema = {
 
 -- Path to the papis.nvim database.
 db_path = vim.fn.stdpath("data") .. "/papis_db/papis-nvim.sqlite3",
+
+-- Name of the `yq` executable.
+yq_bin = "yq",
 
 -- The papis options relevant for papis.nvim (see above minimal config). By
 -- default it is unset, which prompts papis.nvim to call `papis config` to 

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1681228286,
-        "narHash": "sha256-DV9wPPaGfPnpaul9ZrgH/A5rzcjXyIOLnTKfIuYdzxo=",
+        "lastModified": 1682786226,
+        "narHash": "sha256-VX2ms4dv5CaVJbz+5/Qsbhp4wfdjJYhYarV1+NgnTV4=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "86ba8df8d4bd3b7cfa417b4865a78200009b1096",
+        "rev": "11fa51d3714c9cf4c71392b39beba1907ce3ff7a",
         "type": "github"
       },
       "original": {
@@ -164,11 +164,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1681269223,
-        "narHash": "sha256-i6OeI2f7qGvmLfD07l1Az5iBL+bFeP0RHixisWtpUGo=",
+        "lastModified": 1682817260,
+        "narHash": "sha256-kFMXzKNj4d/0Iqbm5l57rHSLyUeyCLMuvlROZIuuhvk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "87edbd74246ccdfa64503f334ed86fa04010bab9",
+        "rev": "db1e4eeb0f9a9028bcb920e00abbc1409dd3ef36",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
                 {
                   packages = [
                     pkgs.sqlitebrowser
+                    pkgs.yq-go
                   ];
                   languages.lua = {
                     enable = true;

--- a/lua/papis/config.lua
+++ b/lua/papis/config.lua
@@ -69,6 +69,7 @@ local default_config = {
     files = "luatable",
   },
   db_path = vim.fn.stdpath("data") .. "/papis_db/papis-nvim.sqlite3",
+  yq_bin = "yq",
   papis_python = nil,
   create_new_note_fn = function(ref, notes_name)
     vim.fn.system(

--- a/lua/papis/init.lua
+++ b/lua/papis/init.lua
@@ -31,13 +31,18 @@ function M.setup(opts)
   config:update(opts)
 
   log = require("papis.logger")
+  log.debug("_________________________SETTING UP PAPIS.NVIM_________________________")
 
-  if not vim.fn.executable("papis") then
-    log.error("The command 'papis' could not be found. Papis must be installed to run papis.nvim")
-    return nil
+  local dependencies = { "papis", config["yq_bin"] }
+  for _, dependency in ipairs(dependencies) do
+    if vim.fn.executable(dependency) == 0 then
+      log.error(
+        string.format("The executable '%s' could not be found. Please install it to use papis.nvim", dependency)
+      )
+      return nil
+    end
   end
 
-  log.debug("_________________________SETTING UP PAPIS.NVIM_________________________")
   log.debug("Creating `PapisStart` command")
   require("papis.commands").setup("init")
   -- make_papis_start()

--- a/lua/papis/papis-storage.lua
+++ b/lua/papis/papis-storage.lua
@@ -12,7 +12,7 @@ local fs_stat = vim.loop.fs_stat
 
 local db = require("papis.sqlite-wrapper")
 if not db then
-	return nil
+  return nil
 end
 local utils = require("papis.utils")
 local log = require("papis.logger")
@@ -28,75 +28,75 @@ local yq_bin = config["yq_bin"]
 --- This function determines if tag format is list, space separated, or comma separated
 ---@param tags any #Either a table or a string with tag(s)
 local function do_determine_tag_format(tags)
-	if type(tags) == "table" then
-		tag_format = "tbl"
-		have_determined_tag_format = true
-	elseif string.find(tags, ",") then
-		tag_format = ","
-		have_determined_tag_format = true
-	elseif string.find(tags, ";") then
-		tag_format = ";"
-		have_determined_tag_format = true
-	elseif string.find(tags, " ") then
-		tag_format = " "
-		have_determined_tag_format = true
-	end
+  if type(tags) == "table" then
+    tag_format = "tbl"
+    have_determined_tag_format = true
+  elseif string.find(tags, ",") then
+    tag_format = ","
+    have_determined_tag_format = true
+  elseif string.find(tags, ";") then
+    tag_format = ";"
+    have_determined_tag_format = true
+  elseif string.find(tags, " ") then
+    tag_format = " "
+    have_determined_tag_format = true
+  end
 end
 
 ---This function converts, if necessary, the tags into a table.
 ---@param tags any #Either a table or a string with tag(s)
 ---@return table #A table with tags
 local function ensure_tags_are_tbl(tags)
-	-- we haven't determined it, it must be a single string tag
-	if not have_determined_tag_format then
-		tags = { tags }
-	-- if it's a table we don't need to do anything
-	elseif tag_format == "tbl" then
-	-- otherwise split the string
-	else
-		tags = utils.do_split_str(tags, tag_format)
-	end
-	return tags
+  -- we haven't determined it, it must be a single string tag
+  if not have_determined_tag_format then
+    tags = { tags }
+  -- if it's a table we don't need to do anything
+  elseif tag_format == "tbl" then
+  -- otherwise split the string
+  else
+    tags = utils.do_split_str(tags, tag_format)
+  end
+  return tags
 end
 
 local function is_valid_entry(entry, path)
-	if entry["ref"] then
-		return true
-	else
-		log.info(string.format("The entry at '%s' is missing a reference and is not added to the database.", path))
-		return false
-	end
+  if entry["ref"] then
+    return true
+  else
+    log.info(string.format("The entry at '%s' is missing a reference and is not added to the database.", path))
+    return false
+  end
 end
 
 local function read_yaml(path)
-	log.trace("Reading path: " .. path)
-	local filepath = Path:new(path)
-    local as_json = io.popen(yq_bin..' -oj "' .. filepath:absolute()..'"'):read("*all")
-	local entry = vim.json.decode(as_json)
-	return entry
+  log.trace("Reading path: " .. path)
+  local filepath = Path:new(path)
+  local as_json = io.popen(yq_bin .. ' -oj "' .. filepath:absolute() .. '"'):read("*all")
+  local entry = vim.json.decode(as_json)
+  return entry
 end
 
 local function do_convert_entry_keys(entry)
-	for key_tbl, key_storage in pairs(key_name_conversions) do
-		if entry[key_storage] then
-			entry[key_tbl] = entry[key_storage]
-		end
-	end
+  for key_tbl, key_storage in pairs(key_name_conversions) do
+    if entry[key_storage] then
+      entry[key_tbl] = entry[key_storage]
+    end
+  end
 
-	return entry
+  return entry
 end
 
 local function make_full_paths(filenames, path)
-	if type(filenames) == "string" then
-		filenames = { filenames }
-	end
+  if type(filenames) == "string" then
+    filenames = { filenames }
+  end
 
-	local full_paths = {}
-	for _, filename in ipairs(filenames) do
-		local full_path = Path:new(path, filename):expand()
-		table.insert(full_paths, full_path)
-	end
-	return full_paths
+  local full_paths = {}
+  for _, filename in ipairs(filenames) do
+    local full_path = Path:new(path, filename):expand()
+    table.insert(full_paths, full_path)
+  end
+  return full_paths
 end
 
 local M = {}
@@ -104,79 +104,73 @@ local M = {}
 ---Gets the opts determined by the papis-storage module
 ---@return table #A table of { k = v, ... } format
 function M.get_state()
-	return { tag_format = tag_format }
+  return { tag_format = tag_format }
 end
 
 ---This function gets mtime of info_name files in a specific path or in all paths
 ---@param paths? table #A list with paths of papis entries
 ---@return table #A list of { path = path, mtime = mtime } values
 function M.get_metadata(paths)
-	paths = paths or Scan.scan_dir(library_dir:expand(), { depth = 2, search_pattern = info_name })
-	local metadata = {}
-	for _, path in ipairs(paths) do
-		local mtime = fs_stat(path).mtime.sec
-		-- path = Path:new(path)
-		-- path = path:parent():absolute()
-		table.insert(metadata, { path = path, mtime = mtime })
-	end
-	return metadata
+  paths = paths or Scan.scan_dir(library_dir:expand(), { depth = 2, search_pattern = info_name })
+  local metadata = {}
+  for _, path in ipairs(paths) do
+    local mtime = fs_stat(path).mtime.sec
+    -- path = Path:new(path)
+    -- path = path:parent():absolute()
+    table.insert(metadata, { path = path, mtime = mtime })
+  end
+  return metadata
 end
 
 ---This function is used to get info for some or all papis entries. Only valid entries are returned.
 ---@param metadata? table #A list with { path = path, mtime = mtime } values
 ---@return table #A list of {{ ref = ref, key = val, ...}, { path = path, mtime = mtime }} values.
 function M.get_data_full(metadata)
-	metadata = metadata or M.get_metadata()
-	local data_complete = {}
-	for _, metadata_v in ipairs(metadata) do
-		local path = metadata_v["path"]
-		local mtime = metadata_v["mtime"]
-		local entry = read_yaml(path)
-		if is_valid_entry(entry, path) then
-			entry = do_convert_entry_keys(entry)
-			local data = {}
-			for key, type_of_val in pairs(data_tbl_schema) do
-				if type(type_of_val) == "table" then
-					type_of_val = type_of_val[1]
-				end
-				if entry[key] then
-					-- determine tag_format when first coming across tags and format tags as table
-					if key == "tags" then
-						if not have_determined_tag_format then
-							do_determine_tag_format(entry[key])
-						else
-							db.state:update({ id = 1 }, { tag_format = tag_format })
-						end
-						entry[key] = ensure_tags_are_tbl(entry[key])
-					end
-					if (key == "files") or (key == "notes") then
-						local entry_path = Path:new(path):parent()
-						entry[key] = make_full_paths(entry[key], entry_path)
-					end
+  metadata = metadata or M.get_metadata()
+  local data_complete = {}
+  for _, metadata_v in ipairs(metadata) do
+    local path = metadata_v["path"]
+    local mtime = metadata_v["mtime"]
+    local entry = read_yaml(path)
+    if is_valid_entry(entry, path) then
+      entry = do_convert_entry_keys(entry)
+      local data = {}
+      for key, type_of_val in pairs(data_tbl_schema) do
+        if type(type_of_val) == "table" then
+          type_of_val = type_of_val[1]
+        end
+        if entry[key] then
+          -- determine tag_format when first coming across tags and format tags as table
+          if key == "tags" then
+            if not have_determined_tag_format then
+              do_determine_tag_format(entry[key])
+            else
+              db.state:update({ id = 1 }, { tag_format = tag_format })
+            end
+            entry[key] = ensure_tags_are_tbl(entry[key])
+          end
+          if (key == "files") or (key == "notes") then
+            local entry_path = Path:new(path):parent()
+            entry[key] = make_full_paths(entry[key], entry_path)
+          end
 
-					-- ensure that everything is of the correct type
-					if type_of_val == "text" then
-						data[key] = tostring(entry[key])
-					elseif type_of_val == "luatable" then
-						if type(entry[key]) == "table" then
-							data[key] = entry[key]
-						else
-							log.warn(
-								"Wanted to add `"
-									.. key
-									.. "` of `"
-									.. entry["ref"]
-									.. "` but the value is not of type `table`"
-							)
-							data[key] = {}
-						end
-					end
-				end
-			end
-			table.insert(data_complete, { data, { path = path, mtime = mtime } })
-		end
-	end
-	return data_complete
+          -- ensure that everything is of the correct type
+          if type_of_val == "text" then
+            data[key] = tostring(entry[key])
+          elseif type_of_val == "luatable" then
+            if type(entry[key]) == "table" then
+              data[key] = entry[key]
+            else
+              log.warn("Wanted to add `" .. key .. "` of `" .. entry["ref"] .. "` but the value is not of type `table`")
+              data[key] = {}
+            end
+          end
+        end
+      end
+      table.insert(data_complete, { data, { path = path, mtime = mtime } })
+    end
+  end
+  return data_complete
 end
 
 return M


### PR DESCRIPTION
Following #19

Instead of parsing the yaml directly we transform it into json via yq and use neovim's native json parsing.

Removes the dependency of lua rocks, thus making installation easier for lazy.