### PR TITLE
quick and dirty solution for inserting formatted reference.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ With the picker open, the following (currently hardcoded) keymaps become availab
 - `of` (normal) / `<c-o>f` (insert): Opens files attached to the entry
 - `on` (normal) / `<c-o>n` (insert): Opens notes attached to the entry (asks for the creation of a new one if none exists)
 - `e` (normal) / `c-e` (insert): Opens the `info.yaml` file
+- `f` (normal) / `c-f` (insert): Insert a formatter reference
 
 ### 'completion' module
 
@@ -231,6 +232,8 @@ data_tbl_schema = {
   time_added = "text",
   notes = "luatable",
   journal = "text",
+  volume = "text",
+  number = "text",
   author_list = "luatable",
   tags = "luatable",
   files = "luatable",
@@ -357,6 +360,23 @@ init_filenames = { "%info_name%", "*.md", "*.norg" },
     vim.api.nvim_buf_set_lines(0, 0, #lines, false, lines)
     -- Move cursor to the bottom
     vim.cmd("normal G")
+  end,
+  -- This function runs when inserting a formatted reference (currently by `f/c-f` in
+  -- Telescope). It works similarly to the `format_notes_fn` above.
+  format_references_fn = function(entry)
+    local reference_format = {
+      { "author",  "%s ",   "" },
+      { "year",    "(%s). ", "" },
+      { "title",   "%s. ",  "" },
+      { "journal", "%s. ",    "" },
+      { "volume",  "%s",    "" },
+      { "number",  "(%s)",  "" },
+    }
+    local reference_data = require("papis.utils"):format_display_strings(entry, reference_format)
+    for k, v in ipairs(reference_data) do
+      reference_data[k] = v[1]
+    end
+    return table.concat(reference_data)
   end,
 },
 

--- a/lua/papis/config.lua
+++ b/lua/papis/config.lua
@@ -65,6 +65,8 @@ local default_config = {
     time_added = "text",
     notes = "luatable",
     journal = "text",
+    volume = "text",
+    number = "text",
     author_list = "luatable",
     tags = "luatable",
     files = "luatable",
@@ -109,6 +111,21 @@ local default_config = {
       }
       vim.api.nvim_buf_set_lines(0, 0, #lines, false, lines)
       vim.cmd("normal G")
+    end,
+    format_references_fn = function(entry)
+      local reference_format = {
+        { "author",  "%s ",   "" },
+        { "year",    "(%s). ", "" },
+        { "title",   "%s. ",  "" },
+        { "journal", "%s. ",    "" },   -- TODO: italicize
+        { "volume",  "%s",    "" },   -- TODO: italicize
+        { "number",  "(%s)",  "" },
+      }
+      local reference_data = require("papis.utils"):format_display_strings(entry, reference_format)
+      for k, v in ipairs(reference_data) do
+        reference_data[k] = v[1]
+      end
+      return table.concat(reference_data)
     end,
   },
   ["cursor-actions"] = {

--- a/lua/papis/config.lua
+++ b/lua/papis/config.lua
@@ -117,8 +117,8 @@ local default_config = {
         { "author",  "%s ",   "" },
         { "year",    "(%s). ", "" },
         { "title",   "%s. ",  "" },
-        { "journal", "%s. ",    "" },   -- TODO: italicize
-        { "volume",  "%s",    "" },   -- TODO: italicize
+        { "journal", "%s. ",    "" },
+        { "volume",  "%s",    "" },
         { "number",  "(%s)",  "" },
       }
       local reference_data = require("papis.utils"):format_display_strings(entry, reference_format)

--- a/lua/telescope/_extensions/papis.lua
+++ b/lua/telescope/_extensions/papis.lua
@@ -100,6 +100,8 @@ local function papis_picker(opts)
         map("n", "on", papis_actions.open_note())
         map("i", "<c-e>", papis_actions.open_info())
         map("n", "e", papis_actions.open_info())
+        map("n", "f", papis_actions.ref_insert_formatted(), {desc="insert formatted reference"})
+        map("i", "<c-f>", papis_actions.ref_insert_formatted(), {desc="insert formatted reference"})
         -- Makes sure that the other defaults are still applied
         return true
       end,

--- a/lua/telescope/_extensions/papis.lua
+++ b/lua/telescope/_extensions/papis.lua
@@ -94,14 +94,14 @@ local function papis_picker(opts)
       sorter = telescope_config.generic_sorter(opts),
       attach_mappings = function(_, map)
         actions.select_default:replace(papis_actions.ref_insert(format_string))
-        map("i", "<c-o>f", papis_actions.open_file())
-        map("n", "of", papis_actions.open_file())
-        map("i", "<c-o>n", papis_actions.open_note())
-        map("n", "on", papis_actions.open_note())
-        map("i", "<c-e>", papis_actions.open_info())
-        map("n", "e", papis_actions.open_info())
-        map("n", "f", papis_actions.ref_insert_formatted(), {desc="insert formatted reference"})
-        map("i", "<c-f>", papis_actions.ref_insert_formatted(), {desc="insert formatted reference"})
+        map("i", "<c-o>f", papis_actions.open_file(), { desc="Open file" })
+        map("n", "of", papis_actions.open_file(), { desc="Open file" })
+        map("i", "<c-o>n", papis_actions.open_note(), { desc="Open note" })
+        map("n", "on", papis_actions.open_note(), { desc="Open note" })
+        map("i", "<c-e>", papis_actions.open_info(), { desc="Open info.yaml file" })
+        map("n", "e", papis_actions.open_info(), { desc="Open info.yaml file" })
+        map("n", "f", papis_actions.ref_insert_formatted(), { desc="Insert formatted reference" })
+        map("i", "<c-f>", papis_actions.ref_insert_formatted(), { desc="Insert formatted reference" })
         -- Makes sure that the other defaults are still applied
         return true
       end,

--- a/lua/telescope/_extensions/papis/actions.lua
+++ b/lua/telescope/_extensions/papis/actions.lua
@@ -6,6 +6,8 @@
 
 local actions = require("telescope.actions")
 local action_state = require("telescope.actions.state")
+local config = require("papis.config")
+local db = require("papis.sqlite-wrapper")
 
 local utils = require("papis.utils")
 
@@ -22,26 +24,15 @@ M.ref_insert = function(format_string)
   end
 end
 
-local insert_format = {
-      { "author", "%s ", "" },
-      { "title", '"%s"', "" },
-      { "journal", "%s", "" },
-      { "volume", 'vol. %s', "" },
-      { "year", "(%s) ", "" },
-    }
-
 M.ref_insert_formatted = function()
   return function(prompt_bufnr)
     actions.close(prompt_bufnr)
-    local entry_id = action_state.get_selected_entry().id
-    local clean_format = utils.do_clean_format_tbl(insert_format, entry_id)
-    local output_fields = {}
-    for _, field in ipairs(utils:format_display_strings(entry_id, clean_format)) do
-    table.insert(output_fields, field[1])
-    end
-    local output = table.concat(output_fields, ", ")
+    local papis_id = action_state.get_selected_entry().id.papis_id
+    local entry = db.data:get({ papis_id = papis_id })[1]
+    vim.print(entry)
+    local reference = config["formatter"]["format_references_fn"](entry)
 
-    vim.api.nvim_put({output}, "", false, true)
+    vim.api.nvim_put({ reference }, "", false, true)
   end
 end
 

--- a/lua/telescope/_extensions/papis/actions.lua
+++ b/lua/telescope/_extensions/papis/actions.lua
@@ -22,30 +22,23 @@ M.ref_insert = function(format_string)
   end
 end
 
+local insert_format = {
+      { "author", "%s ", "" },
+      { "title", '"%s"', "" },
+      { "journal", "%s", "" },
+      { "volume", 'vol. %s', "" },
+      { "year", "(%s) ", "" },
+    }
+
 M.ref_insert_formatted = function()
   return function(prompt_bufnr)
     actions.close(prompt_bufnr)
     local entry_id = action_state.get_selected_entry().id
-    local author = entry_id.author
-    local title = entry_id.title
-    if title ~= nil then
-      title = '"'..title..'"'
-    end
-    local journal = entry_id.journal
-    local volume = entry_id.volume
-    if volume ~= nil then
-      volume = "vol. "..volume
-    end
-    local year = entry_id.year
-    local list = {author, title, journal, volume, year}
-
+    local clean_format = utils.do_clean_format_tbl(insert_format, entry_id)
     local output_fields = {}
-    for _, v in pairs(list) do
-      if v ~= nil then
-        table.insert(output_fields, v)
-      end
+    for _, field in ipairs(utils:format_display_strings(entry_id, clean_format)) do
+    table.insert(output_fields, field[1])
     end
-
     local output = table.concat(output_fields, ", ")
 
     vim.api.nvim_put({output}, "", false, true)

--- a/lua/telescope/_extensions/papis/actions.lua
+++ b/lua/telescope/_extensions/papis/actions.lua
@@ -22,6 +22,36 @@ M.ref_insert = function(format_string)
   end
 end
 
+M.ref_insert_formatted = function()
+  return function(prompt_bufnr)
+    actions.close(prompt_bufnr)
+    local entry_id = action_state.get_selected_entry().id
+    local author = entry_id.author
+    local title = entry_id.title
+    if title ~= nil then
+      title = '"'..title..'"'
+    end
+    local journal = entry_id.journal
+    local volume = entry_id.volume
+    if volume ~= nil then
+      volume = "vol. "..volume
+    end
+    local year = entry_id.year
+    local list = {author, title, journal, volume, year}
+
+    local output_fields = {}
+    for _, v in pairs(list) do
+      if v ~= nil then
+        table.insert(output_fields, v)
+      end
+    end
+
+    local output = table.concat(output_fields, ", ")
+
+    vim.api.nvim_put({output}, "", false, true)
+  end
+end
+
 ---This function opens the files attached to the current entry
 ---@return function
 M.open_file = function()


### PR DESCRIPTION
Hello,

When I type notes or docstrings, I find it very useful to be able to quickly add a formatted reference.
Until csl support is implemented, I have crafted up this quick and dirty solution and I thought I'd share it with the community.

Just a heads-up, this is literally my first shot at doing anything serious with Lua (apart from tweaking my nvim setup), so expect my code to be a bit rough around the edges. 
With this PR, the following behavior is implemented:

typing `f` in normal mode or `<ctrl-f>` in insert mode will insert a formatted reference like the following:

White, R. B., "Guiding center equations for ideal magnetohydrodynamic modes", Physics of Plasmas, 2013