### PR TITLE
fix: remove nvim-treesitter dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ use({
     "kkharji/sqlite.lua",
     "nvim-lua/plenary.nvim",
     "MunifTanjim/nui.nvim",
-    "nvim-treesitter/nvim-treesitter",
   },
   config = function()
     require("papis").setup(
@@ -110,7 +109,6 @@ With lazy.nvim:
     "kkharji/sqlite.lua",
     "nvim-lua/plenary.nvim",
     "MunifTanjim/nui.nvim",
-    "nvim-treesitter/nvim-treesitter",
   },
   config = function()
     require("papis").setup({

--- a/doc/papis.txt
+++ b/doc/papis.txt
@@ -152,7 +152,6 @@ With packer:
         "kkharji/sqlite.lua",
         "nvim-lua/plenary.nvim",
         "MunifTanjim/nui.nvim",
-        "nvim-treesitter/nvim-treesitter",
       },
       config = function()
         require("papis").setup(
@@ -171,7 +170,6 @@ With lazy.nvim:
         "kkharji/sqlite.lua",
         "nvim-lua/plenary.nvim",
         "MunifTanjim/nui.nvim",
-        "nvim-treesitter/nvim-treesitter",
       },
       config = function()
         require("papis").setup({

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,6 @@
             pkgs.vimPlugins.sqlite-lua
             pkgs.vimPlugins.plenary-nvim
             pkgs.vimPlugins.nui-nvim
-            pkgs.vimPlugins.nvim-treesitter
             pkgs.vimPlugins.nvim-treesitter-parsers.yaml
           ];
         };


### PR DESCRIPTION
This wasn't actually used anywhere anymore