### PR TITLE
fix(health): force start papis

### DIFF
--- a/lua/papis/health.lua
+++ b/lua/papis/health.lua
@@ -81,6 +81,10 @@ local M = {}
 
 ---Main function called by checkhealth
 M.check = function()
+  -- make sure papis.nvim is started as checkhealth can be called outside
+  -- configured filetypes
+  require("papis").start()
+
   if not health then
     health = vim.health
   end


### PR DESCRIPTION
required so `checkhealth papis` works when called outside a configured filetype buffer. see #82 for discussion of issue.