### PR TITLE
Simplify tag handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,11 +513,6 @@ enable_icons = true,
     time_added = "time-added",
   },
 
-  -- The format used for tags. Will be determined automatically if left empty.
-  -- Can be set to `tbl` (if a lua table), `,` (if comma-separated), `:` (if
-  -- semi-colon separated), ` ` (if space separated).
-  tag_format = nil,
-
   -- The keys which `.yaml` files are expected to always define. Files that are
   -- missing these keys will cause an error message and will not be added to
   -- the database.

--- a/doc/papis.txt
+++ b/doc/papis.txt
@@ -1,4 +1,4 @@
-*papis.txt*              For NVIM v0.8.0              Last change: 2025 May 21
+*papis.txt*              For NVIM v0.8.0             Last change: 2025 July 27
 
 ==============================================================================
 Table of Contents                                    *papis-table-of-contents*
@@ -551,11 +551,6 @@ All configuration options (with defaults) ~
       key_name_conversions = {
         time_added = "time-added",
       },
-    
-      -- The format used for tags. Will be determined automatically if left empty.
-      -- Can be set to `tbl` (if a lua table), `,` (if comma-separated), `:` (if
-      -- semi-colon separated), ` ` (if space separated).
-      tag_format = nil,
     
       -- The keys which `.yaml` files are expected to always define. Files that are
       -- missing these keys will cause an error message and will not be added to

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1743550720,
-        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "lastModified": 1751413152,
+        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744868846,
-        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
+        "lastModified": 1751949589,
+        "narHash": "sha256-mgFxAPLWw0Kq+C8P3dRrZrOYEQXOtKuYVlo9xvPntt8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
+        "rev": "9b008d60392981ad674e04016d25619281550a9d",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1743296961,
-        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "lastModified": 1751159883,
+        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
         "type": "github"
       },
       "original": {

--- a/lua/papis/completion/blink/init.lua
+++ b/lua/papis/completion/blink/init.lua
@@ -15,9 +15,6 @@ if not common then
   return nil
 end
 
-local show_on_blocked_trigger_characters_backup = require("blink.cmp.config").completion.trigger
-    .show_on_blocked_trigger_characters
-
 --- @module 'blink.cmp completion source'
 --- @class papis.completion.blink
 local M = {}
@@ -34,52 +31,33 @@ M.get_trigger_characters = common.get_trigger_characters
 
 ---Ensures that this source is only available in info_name files, and only for the "tags" key
 ---@return boolean #True if info_name file, false otherwise
-function M:enabled()
-  local is_available = common:is_available()
-  -- HACK: there doesn't seem to be a way to set this for an individual source
-  if is_available then
-    require("blink.cmp.config").completion.trigger.show_on_blocked_trigger_characters = {}
-  else
-    log.debug("asdasdasdads: " .. vim.inspect(show_on_blocked_trigger_characters_backup))
-    require("blink.cmp.config").completion.trigger.show_on_blocked_trigger_characters =
-        show_on_blocked_trigger_characters_backup
-  end
-  return is_available
-end
+M.enabled = common.is_available
 
 ---Completes the current request
----@param ctx table
+---@param _ table #The ctx table
 ---@param callback function
-function M:get_completions(ctx, callback)
+function M:get_completions(_, callback)
+  -- Insert a space after the dash and move cursor
+  local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+  vim.api.nvim_buf_set_text(0, row - 1, col, row - 1, col, { " " })
+  vim.api.nvim_win_set_cursor(0, { row, col + 1 })
+
   log.debug("Getting completions")
-  local col = ctx.cursor[2] + 1
-  local prefix = ctx.line:sub(1, col + 2)
-
-  -- complete if after tag_delimiter
-  local comp_after_tag_delimiter = vim.endswith(prefix, common.get_tag_delimiter())
-  -- complete if after 'tags: ' keyword and not table tag format
-  local comp_after_keyword = (prefix == "tags: ") and not (common.get_tag_delimiter() == "- ")
-
-  if comp_after_tag_delimiter or comp_after_keyword then
-    log.debug("Running cmp `complete()` function.")
-    local tag_strings = db.completion:get()[1].tag_strings
-    --- @type lsp.CompletionItem[]
-    local items = {}
-    for _, tag in ipairs(tag_strings) do
-      --- @type lsp.CompletionItem
-      local item = {
-        label = tag.label,
-      }
-      table.insert(items, item)
-    end
-    callback({
-      items = items,
-      is_incomplete_backward = false,
-      is_incomplete_forward = false,
-    })
-  else
-    callback({})
+  local tag_strings = db.completion:get()[1].tag_strings
+  --- @type lsp.CompletionItem[]
+  local items = {}
+  for _, tag in ipairs(tag_strings) do
+    --- @type lsp.CompletionItem
+    local item = {
+      label = tag.label,
+    }
+    table.insert(items, item)
   end
+  callback({
+    items = items,
+    is_incomplete_backward = false,
+    is_incomplete_forward = false,
+  })
 end
 
 return M

--- a/lua/papis/completion/blink/init.lua
+++ b/lua/papis/completion/blink/init.lua
@@ -27,7 +27,9 @@ end
 
 ---Gets trigger characters
 ---@return table
-M.get_trigger_characters = common.get_trigger_characters
+function M.get_trigger_characters()
+  return { "-" }
+end
 
 ---Ensures that this source is only available in info_name files, and only for the "tags" key
 ---@return boolean #True if info_name file, false otherwise

--- a/lua/papis/completion/cmp/init.lua
+++ b/lua/papis/completion/cmp/init.lua
@@ -27,7 +27,9 @@ end
 
 ---Gets trigger characters
 ---@return table
-M.get_trigger_characters = common.get_trigger_characters
+function M:get_trigger_characters()
+  return { " " }
+end
 
 ---Ensures that this source is only available in info_name files, and only for the "tags" key
 ---@return boolean #True if info_name file, false otherwise

--- a/lua/papis/completion/cmp/init.lua
+++ b/lua/papis/completion/cmp/init.lua
@@ -31,29 +31,20 @@ M.get_trigger_characters = common.get_trigger_characters
 
 ---Ensures that this source is only available in info_name files, and only for the "tags" key
 ---@return boolean #True if info_name file, false otherwise
-function M:is_available()
-  local is_available = common:is_available()
-  return is_available
-end
+M.is_available = common.is_available
 
 ---Completes the current request
----@param request table
+---@param _ table #The request
 ---@param callback function
-function M:complete(request, callback)
-  log.debug("offset: " .. request.offset)
-  local prefix = string.sub(request.context.cursor_before_line, 1, request.offset)
-  log.debug("Request prefix: " .. prefix)
+function M:complete(_, callback)
+  -- Insert a space after the dash and move cursor
+  local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+  vim.api.nvim_buf_set_text(0, row - 1, col, row - 1, col, { " " })
+  vim.api.nvim_win_set_cursor(0, { row, col + 1 })
 
-  -- complete if after tag_delimiter
-  local comp_after_tag_delimiter = vim.endswith(prefix, common.get_tag_delimiter())
-  -- complete if after 'tags: ' keyword and not table tag format
-  local comp_after_keyword = (prefix == "tags: ") and not (common.get_tag_delimiter() == "- ")
-
-  if comp_after_tag_delimiter or comp_after_keyword then
-    log.debug("Running cmp `complete()` function.")
-    self.items = db.completion:get()[1].tag_strings
-    callback(self.items)
-  end
+  log.debug("Running cmp `complete()` function.")
+  self.items = db.completion:get()[1].tag_strings
+  callback(self.items)
 end
 
 return M

--- a/lua/papis/completion/cmp/init.lua
+++ b/lua/papis/completion/cmp/init.lua
@@ -36,17 +36,20 @@ end
 M.is_available = common.is_available
 
 ---Completes the current request
----@param _ table #The request
+---@param request table
 ---@param callback function
-function M:complete(_, callback)
-  -- Insert a space after the dash and move cursor
-  local row, col = unpack(vim.api.nvim_win_get_cursor(0))
-  vim.api.nvim_buf_set_text(0, row - 1, col, row - 1, col, { " " })
-  vim.api.nvim_win_set_cursor(0, { row, col + 1 })
+function M:complete(request, callback)
+  local prefix = string.sub(request.context.cursor_before_line, 1, request.offset)
+  log.debug("Request prefix: " .. prefix)
 
-  log.debug("Running cmp `complete()` function.")
-  self.items = db.completion:get()[1].tag_strings
-  callback(self.items)
+  -- complete if after tag_delimiter
+  local comp_after_tag_delimiter = vim.endswith(prefix, "- ")
+
+  if comp_after_tag_delimiter then
+    log.debug("Running cmp `complete()` function.")
+    self.items = db.completion:get()[1].tag_strings
+    callback(self.items)
+  end
 end
 
 return M

--- a/lua/papis/completion/common.lua
+++ b/lua/papis/completion/common.lua
@@ -14,16 +14,6 @@ local ts = vim.treesitter
 local Path = require("pathlib")
 local api = vim.api
 
-local tag_delimiter
-
--- Mapping table for tag delimiters
-local tag_delimiters = {
-  tbl = "- ",
-  [","] = ", ",
-  [";"] = "; ",
-  [" "] = " ",
-}
-
 local parse_query = ts.query.parse(
   "yaml",
   [[
@@ -36,26 +26,15 @@ local parse_query = ts.query.parse(
 
 local M = {}
 
----Gets the tag delimiter
----@return string #tag_delimiter
-function M.get_tag_delimiter()
-  if not tag_delimiter then
-    local tag_format = db.state:get_value({ id = 1 }, "tag_format")
-    tag_delimiter = tag_delimiters[tag_format]
-    log.debug("Tag delimiter: " .. tag_delimiter)
-  end
-  return tag_delimiter
-end
-
 ---Gets trigger characters
 ---@return table
-function M:get_trigger_characters()
-  return { " " }
+function M.get_trigger_characters()
+  return { "-" }
 end
 
 ---Ensures that this source is only available in info_name files, and only for the "tags" key
 ---@return boolean #True if info_name file, false otherwise
-function M:is_available()
+function M.is_available()
   local is_available = false
   local current_filepath = Path(api.nvim_buf_get_name(0))
   local filename = current_filepath:basename()
@@ -64,20 +43,25 @@ function M:is_available()
   if filename == info_name then
     log.trace("we are in a papis info file")
 
-    if M.get_tag_delimiter() then
-      local parser = ts.get_parser(0, "yaml")
-      local root = parser:parse()[1]:root()
-      local start_row, _, _, end_row, _, _ = unpack(ts.get_range(root))
-      local cur_row, _ = unpack(api.nvim_win_get_cursor(0))
-      -- check all captured nodes
-      for id, node, _ in parse_query:iter_captures(root, 0, start_row, end_row) do
-        local name = parse_query.captures[id]
-        -- check if the capture is named "capture" (see query above)
-        if name == "capture" then
-          local node_start, _, _, node_end, _, _ = unpack(ts.get_range(node))
-          log.trace("start_line: " .. node_start .. "; cur_line: " .. cur_row .. "; end_line: " .. node_end)
-          -- check if cursor line is within captured node
-          if node_start <= cur_row and (node_end + 1) >= cur_row then
+    local parser = ts.get_parser(0, "yaml")
+    local root = parser:parse()[1]:root()
+    local start_row, _, _, end_row, _, _ = unpack(ts.get_range(root))
+    local cur_row, cur_col = unpack(api.nvim_win_get_cursor(0))
+    -- check all captured nodes
+    for id, node, _ in parse_query:iter_captures(root, 0, start_row, end_row) do
+      local name = parse_query.captures[id]
+      -- check if the capture is named "capture" (see query above)
+      if name == "capture" then
+        local node_start, _, _, node_end, _, _ = unpack(ts.get_range(node))
+        log.trace("start_line: " .. node_start .. "; cur_line: " .. cur_row .. "; end_line: " .. node_end)
+        -- check if cursor line is within captured node
+        if node_start <= cur_row and (node_end + 1) >= cur_row then
+          -- Check if current character is a dash and if it's at the beginning of a line
+          local line = api.nvim_buf_get_lines(0, cur_row - 1, cur_row, false)[1]
+          local trimmed_line_start = line:sub(1, cur_col):match("^%s*(.*)$")
+
+          -- Only proceed if we're at the start of a line (possibly with whitespace)
+          if trimmed_line_start == "-" then
             log.trace("completion is available")
             is_available = true
           end

--- a/lua/papis/completion/common.lua
+++ b/lua/papis/completion/common.lua
@@ -26,12 +26,6 @@ local parse_query = ts.query.parse(
 
 local M = {}
 
----Gets trigger characters
----@return table
-function M.get_trigger_characters()
-  return { "-" }
-end
-
 ---Ensures that this source is only available in info_name files, and only for the "tags" key
 ---@return boolean #True if info_name file, false otherwise
 function M.is_available()
@@ -60,11 +54,8 @@ function M.is_available()
           local line = api.nvim_buf_get_lines(0, cur_row - 1, cur_row, false)[1]
           local trimmed_line_start = line:sub(1, cur_col):match("^%s*(.*)$")
 
-          -- Only proceed if we're at the start of a line (possibly with whitespace)
-          if trimmed_line_start == "-" then
-            log.trace("completion is available")
-            is_available = true
-          end
+          log.trace("completion is available")
+          is_available = true
         end
       end
     end

--- a/lua/papis/config.lua
+++ b/lua/papis/config.lua
@@ -179,7 +179,6 @@ local default_config = {
     key_name_conversions = {
       time_added = "time-added",
     },
-    tag_format = nil,
     required_keys = { "papis_id", "ref" },
   },
 }

--- a/lua/papis/papis-storage.lua
+++ b/lua/papis/papis-storage.lua
@@ -138,6 +138,13 @@ function M.get_data_full(metadata)
           type_of_val = type_of_val[1]
         end
         if entry[key] then
+          -- determine tag_format when first coming across tags and format tags as table
+          if key == "tags" then
+            if type(entry[key]) ~= "table" then
+              error(
+                "The tag format isn't a list. Please convert your info.yaml files with `papis doctor -t key-type` to use papis.nvim.")
+            end
+          end
           if (key == "files") or (key == "notes") then
             local entry_path = Path(path):parent()
             entry[key] = make_full_paths(entry[key], entry_path)

--- a/lua/papis/papis-storage.lua
+++ b/lua/papis/papis-storage.lua
@@ -13,49 +13,12 @@ local db = require("papis.sqlite-wrapper")
 if not db then
   return nil
 end
-local utils = require("papis.utils")
 local log = require("papis.log")
 local config = require("papis.config")
 local data_tbl_schema = config.data_tbl_schema
 local key_name_conversions = config["papis-storage"].key_name_conversions
 local required_keys = config["papis-storage"].required_keys
-local tag_format = config["papis-storage"].tag_format
-local have_determined_tag_format = false
 local yq_bin = config.yq_bin
-
----Determines if tag format is list, space separated, or comma separated
----@param tags any #Either a table or a string with tag(s)
-local function do_determine_tag_format(tags)
-  if type(tags) == "table" then
-    tag_format = "tbl"
-    have_determined_tag_format = true
-  elseif string.find(tags, ",") then
-    tag_format = ","
-    have_determined_tag_format = true
-  elseif string.find(tags, ";") then
-    tag_format = ";"
-    have_determined_tag_format = true
-  elseif string.find(tags, " ") then
-    tag_format = " "
-    have_determined_tag_format = true
-  end
-end
-
----Converts, if necessary, the tags into a table.
----@param tags any #Either a table or a string with tag(s)
----@return table #A table with tags
-local function ensure_tags_are_tbl(tags)
-  -- we haven't determined it, it must be a single string tag
-  if not have_determined_tag_format then
-    tags = { tags }
-    -- if it's a table we don't need to do anything
-  elseif tag_format == "tbl" then
-    -- otherwise split the string
-  else
-    tags = utils.do_split_str(tags, tag_format)
-  end
-  return tags
-end
 
 ---Checks if a decoded entry is valid
 ---@param entry table|nil #The entry as a table or nil if entry wasn't read properly before
@@ -135,12 +98,6 @@ end
 
 local M = {}
 
----Gets the opts determined by the papis-storage module
----@return table #A table of { k = v, ... } format
-function M.get_state()
-  return { tag_format = tag_format }
-end
-
 ---This function gets mtime of info_name files in a specific path or in all paths
 ---@param paths? table #A list with paths of papis entries
 ---@return table #A list of { path = path, mtime = mtime } values
@@ -181,15 +138,6 @@ function M.get_data_full(metadata)
           type_of_val = type_of_val[1]
         end
         if entry[key] then
-          -- determine tag_format when first coming across tags and format tags as table
-          if key == "tags" then
-            if not have_determined_tag_format then
-              do_determine_tag_format(entry[key])
-            else
-              db.state:update({ id = 1 }, { tag_format = tag_format })
-            end
-            entry[key] = ensure_tags_are_tbl(entry[key])
-          end
           if (key == "files") or (key == "notes") then
             local entry_path = Path(path):parent()
             entry[key] = make_full_paths(entry[key], entry_path)

--- a/lua/papis/search/snacks/init.lua
+++ b/lua/papis/search/snacks/init.lua
@@ -46,6 +46,7 @@ function M.preview(ctx)
   local preview_lines = utils:make_nui_lines(config["search"].preview_format, entry)
 
   vim.bo[ctx.buf].modifiable = true
+  vim.api.nvim_buf_set_lines(ctx.buf, 0, -1, false, {})
   for line_nr, line in ipairs(preview_lines) do
     line:render(ctx.buf, -1, line_nr)
   end

--- a/lua/papis/sqlite-wrapper.lua
+++ b/lua/papis/sqlite-wrapper.lua
@@ -220,7 +220,6 @@ local schemas = {
   state = {
     id = true,
     fw_running = { "integer" },
-    tag_format = { "text" },
     db_last_modified = { "integer", default = os.time() },
   },
   config = get_config_tbl_schema(),

--- a/nix/ci-overlay.nix
+++ b/nix/ci-overlay.nix
@@ -29,8 +29,8 @@ let
         plugins = with vimPlugins; [
           # telescope-nvim
           snacks-nvim
-          # nvim-cmp
-          blink-cmp
+          nvim-cmp
+          # blink-cmp
           (nvim-treesitter.withPlugins (
             ps: with ps; [
               tree-sitter-yaml
@@ -96,28 +96,28 @@ let
             vim.keymap.set("", "<f1>", toggle_profile)
 
             -- cmp
-            -- local cmp = require("cmp")
-            -- cmp.setup({
-            --   mapping = cmp.mapping.preset.insert({
-            --     ["<C-b>"] = cmp.mapping.scroll_docs(-4),
-            --     ["<C-f>"] = cmp.mapping.scroll_docs(4),
-            --     ["<C-Space>"] = cmp.mapping.complete(),
-            --     ["<C-e>"] = cmp.mapping.abort(),
-            --     ["<CR>"] = cmp.mapping.confirm({ select = true }), -- Accept currently selected item. Set `select` to `false` to only confirm explicitly selected items.
-            --   }),
-            --   sources = cmp.config.sources({
-            --     { name = "papis" },
-            --   }),
-            -- })
-            -- blink
-            local blink = require("blink.cmp")
-            blink.setup({
-              sources = {
-                per_filetype = {
-                  yaml = { "papis" }
-                },
-              },
+            local cmp = require("cmp")
+            cmp.setup({
+              mapping = cmp.mapping.preset.insert({
+                ["<C-b>"] = cmp.mapping.scroll_docs(-4),
+                ["<C-f>"] = cmp.mapping.scroll_docs(4),
+                ["<C-Space>"] = cmp.mapping.complete(),
+                ["<C-e>"] = cmp.mapping.abort(),
+                ["<CR>"] = cmp.mapping.confirm({ select = true }), -- Accept currently selected item. Set `select` to `false` to only confirm explicitly selected items.
+              }),
+              sources = cmp.config.sources({
+                { name = "papis" },
+              }),
             })
+            -- blink
+            -- local blink = require("blink.cmp")
+            -- blink.setup({
+            --   sources = {
+            --     per_filetype = {
+            --       yaml = { "papis" }
+            --     },
+            --   },
+            -- })
 
             -- telescope
             -- local telescope = require("telescope")


### PR DESCRIPTION
We no longer handle tags being anything but yaml lists. This will make maintaining the code easier and aligns with Papis upstream behaviour (see https://github.com/papis/papis/pull/914).